### PR TITLE
Distance Sanity Check?

### DIFF
--- a/FCNPC/Natives.cpp
+++ b/FCNPC/Natives.cpp
@@ -51,6 +51,7 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_Spawn(AMX *amx, cell *params)
 	int iNPCId = (int)params[1];
 	// Get the NPC skin id
 	int iSkin = (int)params[2];
+	
 	// Get the position coordinates
 	float fX = amx_ctof(params[3]);
 	float fY = amx_ctof(params[4]);
@@ -625,6 +626,13 @@ cell AMX_NATIVE_CALL CNatives::FCNPC_AimAt(AMX *amx, cell *params)
 	if(!pServer->GetPlayerManager()->IsPlayerConnected(iNPCId))
 		return 0;
 
+        pServer->GetPlayerManager()->GetAt(iNPCId)->GetPosition(&vecPosition);
++        
++        if(amx_ftoc(vecPosition.fX) >= fX+30.0 || amx_ftoc(vecPosition.fY) >= fY+30.0)
++        {
++        	// The coordinates are too far away to shoot at.
++                return 0;
++        }
 	// Set the player aiming
 	pServer->GetPlayerManager()->GetAt(iNPCId)->AimAt(CVector3(fX, fY, fZ), !iShoot ? false : true);
 	return 1;


### PR DESCRIPTION
This will attempt to fix a weird bending (more of a detachment) from the upper body area from the lower body area which is caused by the NPC trying to shoot somewhere they physically can't(or maybe is unstreamed for them?). Anyways, I believe this may fix the issue a bit - however there are some additional bugs with the rotation of the aim that may cause this issue as well.

I haven't tested this however I remember this happening when the distance was above 30 meters so this is a probable solution.
